### PR TITLE
レビュー実行ボタンを変換未完了時にdisabledに変更

### DIFF
--- a/versions/v0.5.1/frontend/index.html
+++ b/versions/v0.5.1/frontend/index.html
@@ -325,7 +325,8 @@
       <button onclick="executeReview()" id="review-btn" class="w-full bg-green-500 hover:bg-green-600 text-white font-bold py-4 rounded-lg shadow-md transition text-lg disabled:bg-gray-300 disabled:cursor-not-allowed" disabled>
         レビュー実行
       </button>
-      <p class="text-xs text-gray-400 mt-3 text-center">※ 同じ設定でレビューを2回実行します。それぞれ個別に結果を確認できます。</p>
+      <p id="review-btn-warning" class="text-xs text-orange-500 mt-3 text-center">※ レビューを実行するには、設計書とプログラムを両方変換してください。</p>
+      <p class="text-xs text-gray-400 mt-1 text-center">※ 同じ設定でレビューを2回実行します。それぞれ個別に結果を確認できます。</p>
     </div>
   </div>
 
@@ -734,10 +735,13 @@
     // レビューボタンの状態を更新する関数
     function updateReviewButtonState() {
       const reviewBtn = document.getElementById('review-btn');
+      const reviewBtnWarning = document.getElementById('review-btn-warning');
       if (specMarkdown && codeWithLineNumbers) {
         reviewBtn.disabled = false;
+        reviewBtnWarning.classList.add('hidden');
       } else {
         reviewBtn.disabled = true;
+        reviewBtnWarning.classList.remove('hidden');
       }
     }
 


### PR DESCRIPTION
## 問題点

「AIレビュー実行」ボタンについて、設計書とプログラムの変換が完了していない状態でクリックすると、アラートが表示される仕様になっていました。

この動作は以下の点で改善の余地がありました：
- ユーザーがクリックして初めてエラーがわかるため、操作性が悪い
- ボタンが有効に見えるため、クリック可能と誤解される

## 修正内容

- レビュー実行ボタンの初期状態を `disabled` に変更
- `updateReviewButtonState()` 関数を追加し、設計書・プログラム両方の変換が完了した場合のみボタンを有効化
- 以下のタイミングでボタン状態を更新:
  - 設計書/プログラムファイル選択時
  - 設計書/プログラム変換完了時
  - メイン設計書変更時
  - 種別・ツール変更時
  - 一括ツール適用時
- `executeReview()` 関数内のアラート表示を削除

## 変更ファイル

- `versions/v0.5.1/frontend/index.html`

## Test plan

- [ ] 初期状態でレビュー実行ボタンが disabled（グレーアウト）になっていることを確認
- [ ] 設計書のみ変換した状態でボタンが disabled のままであることを確認
- [ ] プログラムのみ変換した状態でボタンが disabled のままであることを確認
- [ ] 設計書・プログラム両方を変換後、ボタンが有効になることを確認
- [ ] 変換後にファイルを再選択すると、ボタンが再び disabled になることを確認
- [ ] 変換後に設定（メイン設計書、種別、ツール）を変更すると、ボタンが disabled になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)