### PR TITLE
MarkItDown を用いた Word（.docx）対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,9 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+# Claude (Anthropic Claude Code / Cursor 等)
+.claude
+
 # Cursor
 #  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data

--- a/docs/20260125-word-support-plan.md
+++ b/docs/20260125-word-support-plan.md
@@ -1,0 +1,127 @@
+# Word対応 有効化 変更計画書
+
+作成日: 2026-01-25
+更新日: 2026-01-25
+
+> **パス表記**: 想定変更箇所のパスは `versions/v0.7.0/` を基準とする。実体は `versions/v0.7.0/frontend/` 等で要確認。
+
+## 目的
+AIレビュアーでWordファイル（主に`.docx`）を**ファイル形式として**選択・変換できるようにし、**複数ファイル混在時でも `.docx` は必ず MarkItDown で変換**されるようにする。
+
+## 背景
+- MarkItDownはWord対応だが、UI/フロー上でWordを明示選択できない。
+- Word選択時に他ツール（excel2md等）が選べると不整合が起きる。
+
+## 対象範囲
+- フロントエンドのファイル種別選択UI
+- ファイル入力コンポーネントの受付拡張子
+- 変換ツール選択UIとバリデーション
+- 変換リクエスト生成ロジック
+
+## 非対象（今回やらない）
+- バックエンドのMarkItDown依存追加（別途対応）
+- バックエンドAPIの拡張子チェック修正（別途対応）
+- `.doc`（旧Word形式）の対応
+- 変換品質の改善や差分検証
+
+## 要件
+1. UIでWord（.docx）を選択できること（ファイル形式として）
+2. 複数ファイルを選んだ場合でも、`.docx` には常に `markitdown` が適用されること
+3. Word（.docx）行のツール選択はMarkItDownのみ表示・選択可能であること
+4. Word（.docx）送信時の`tool`は必ず`markitdown`になること
+
+## 変更方針
+- Word対応は**ファイル形式（拡張子）**で扱う。種別（spec type）にはWordを追加しない
+- Word（.docx）行のツール選択UIを固定（選択不可 or MarkItDownのみ表示）
+- 既存のバリデーション/デフォルト割当ロジックで `.docx` を明示的に分岐
+
+### Word判定の方式
+Word判定は**ファイル拡張子のみ**で行う（`.docx`）。`type`（種別）はファイル形式ではないため、Word判定には使わない。
+
+`.docx` を `addSpecFiles` で追加した際は、`type` は `DEFAULT_TYPE`（設計書）のまま、`tool` のみ `'markitdown'` に設定する。
+
+## 想定変更箇所
+
+### 1. ファイル入力コンポーネント
+- `versions/v0.7.0/frontend/src/features/reviewer/index.tsx`
+  - `FileInputButton` の `accept` 属性に `.docx` を追加
+  - 現状: `accept=".xlsx,.xls"` → 変更後: `accept=".xlsx,.xls,.docx"`
+  - カード見出しを「設計書 (Excel)」から「設計書 (Excel / Word)」に変更
+
+### 2. ファイル種別の設定
+- **変更なし**。`specTypes` はレビュー用の「種別」であり、ファイル形式ではないためWord項目は追加しない。
+
+### 3. ファイル変換フック
+- `versions/v0.7.0/frontend/src/features/reviewer/hooks/useFileConversion.ts`
+  - Word判定用のヘルパー関数を追加
+  - **addSpecFiles**
+    - 拡張子 `.doc` のファイルを除外し、除外した件数があれば `setSpecStatus` でエラーメッセージを設定
+    - 除外後、`isMain` は「除外後のリストの先頭」に付与
+    - `.docx` のファイルには `tool: 'markitdown'` を設定。`type` は `DEFAULT_TYPE` のまま（Word 判定は拡張子を主とする）
+  - **setSpecTool**: Word ファイルに対して `excel2md` 等を渡そうとした場合は無視する（ガード）
+  - **applyToolToAll**: 一括で excel2md を選んだ場合、Word（.docx）ファイルには適用しない（Word は markitdown のまま）
+  - **convertSpecs**: API 呼び出し時に、Word の場合は `tool` を `'markitdown'` に正規化してから送信（防御的な二重チェック）
+
+### 4. ファイルリストUI
+- `versions/v0.7.0/frontend/src/features/reviewer/components/SpecFileList.tsx`
+  - Word（.docx）ファイル行のツール選択 UI を固定（MarkItDownのみ表示/disabled）
+  - 「WordはMarkItDownのみ対応」の補足テキスト表示
+  - **一括設定**: 一括で excel2md を選んだ場合の Word 除外は `useFileConversion.applyToolToAll` 内で行う。任意で、Word が 1 件でも含まれるときに excel2md の一括ボタンを無効化する UI にしてもよい。
+
+## UI仕様（案）
+- Word（.docx）ファイル行のツール選択
+  - 表示: 「MarkItDown」のみ
+  - 操作: 選択不可（固定）
+  - 補足文: 「WordはMarkItDownのみ対応」等の説明を表示
+- `.doc` ファイルがアップロードされた場合（`addSpecFiles` 内で除外し、`setSpecStatus` で表示）
+  - 基本: 「.doc形式は非対応です。.docx形式で保存し直してください」
+  - 他形式と混在して .doc のみ除外した場合は、「（n件を除外）」等を付与してよい
+
+## 受け入れ条件
+- Wordファイル（.docx）を選択できる
+- 複数ファイル混在時でも、`.docx` は常に MarkItDown に固定される
+- Word（.docx）行で他ツールが選べない
+- Word（.docx）送信時のリクエストが`tool: markitdown`で送信される
+- 既存のExcelなどの挙動が変わらない
+- .docファイルは拒否され、適切なエラーメッセージが表示される
+
+## テスト観点
+- Word（.docx）ファイルが選択できる
+- 複数ファイル混在時でも `.docx` 行のツールがMarkItDownに固定される
+- 一括ツール適用時でも `.docx` はMarkItDownのまま
+- Word以外のファイル選択時は従来通りツール選択が可能
+- 画面リロード後も選択状態が崩れない
+- .docファイルがアップロードされた場合にエラーが表示される
+
+## バックエンドとの連携方針
+
+### 前提条件
+バックエンド側では現在、`/api/convert/excel-to-markdown` エンドポイントで `.xlsx`, `.xls` のみを受け付けている。Word対応には以下のバックエンド修正が別途必要：
+- `versions/v0.7.0/backend/app/routers/convert.py` の拡張子チェックに `.docx` を追加
+
+### リリース方針
+以下のいずれかを選択する：
+
+**案A: 同時リリース（推奨）**
+- フロントエンドとバックエンドの修正を同時にリリース
+- ユーザーは即座にWord変換機能を利用可能
+
+**案B: 段階的リリース**
+- フロントエンドを先行リリースし、Word選択UIに「準備中」と表示
+- バックエンド対応完了後にUI制限を解除
+
+## リスク/留意点
+- Word対応のバックエンド依存が未導入だと変換が失敗する
+  - → バックエンド対応と同時リリースを前提とする
+- `.doc`非対応であることをUIで明示する必要がある
+  - → アップロード時にエラーメッセージを表示
+- APIエンドポイント名が `excel-to-markdown` のままになる
+  - → 将来的に汎用的な名称への変更を検討（バックエンド側の課題）
+
+## 進め方（作業手順）
+1. `index.tsx`: FileInputButton の `accept` に `.docx` を追加し、カード見出しを「設計書 (Excel / Word)」に変更
+2. `useFileConversion.ts`: Word 判定ヘルパー、addSpecFiles（.doc 除外・setSpecStatus・isMain の付け直し・.docx 時の tool 設定）、setSpecTool のガード、applyToolToAll の Word 除外、convertSpecs の tool 正規化を追加
+3. `SpecFileList.tsx`: Word（.docx）行のツール固定、補足文を実装。一括設定の Word 除外は 2. の `applyToolToAll` で対応済み。任意で、Word が 1 件でも含まれるときに excel2md の一括ボタンを無効化する UI を追加してもよい
+4. `.doc` のエラーハンドリングは 2. の `addSpecFiles` 内で実施（.doc を除外し、除外件数があれば `setSpecStatus` で「.doc形式は非対応です。.docx形式で保存し直してください」等を表示）
+5. 既存のファイル種別（Excel 等）でリグレッション確認
+6. バックエンド対応と合わせて結合テスト

--- a/excel2md/.claude/settings.json
+++ b/excel2md/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git mv:*)"
-    ]
-  }
-}

--- a/versions/v0.7.0/frontend/src/features/reviewer/components/SpecFileList.tsx
+++ b/versions/v0.7.0/frontend/src/features/reviewer/components/SpecFileList.tsx
@@ -32,6 +32,7 @@ export function SpecFileList({
   onDownload,
 }: SpecFileListProps) {
   const [isPreviewOpen, setIsPreviewOpen] = useState(true)
+  const isDocxFilename = (filename: string) => filename.toLowerCase().endsWith('.docx')
 
   if (files.length === 0) return null
 
@@ -61,50 +62,61 @@ export function SpecFileList({
 
       {/* File list */}
       <div className="space-y-2">
-        {files.map((file) => (
-          <div
-            key={file.filename}
-            className="flex flex-col gap-1 text-sm bg-gray-50 border border-gray-200 rounded px-3 py-2"
-          >
-            <span className="text-gray-700 break-words">{file.filename}</span>
-            <div className="flex flex-wrap items-center gap-2">
-              <label className="flex items-center gap-1 cursor-pointer">
-                <input
-                  type="radio"
-                  name="main-spec"
-                  checked={file.isMain}
-                  onChange={() => onMainChange(file.filename)}
-                  className="w-4 h-4 text-blue-600 cursor-pointer"
-                />
-                <span className="text-xs text-gray-500 font-bold">メイン</span>
-              </label>
-              <span className="text-xs text-gray-500 ml-2">種別</span>
-              <select
-                value={file.type}
-                onChange={(e) => onTypeChange(file.filename, e.target.value)}
-                className="border border-gray-300 rounded px-2 py-1 text-sm"
-              >
-                {specTypesList.map((type) => (
-                  <option key={type} value={type}>
-                    {type}
-                  </option>
-                ))}
-              </select>
-              <span className="text-xs text-gray-500">ツール</span>
-              <select
-                value={file.tool}
-                onChange={(e) => onToolChange(file.filename, e.target.value)}
-                className="border border-gray-300 rounded px-2 py-1 text-sm"
-              >
-                {availableTools.map((t) => (
-                  <option key={t.name} value={t.name}>
-                    {t.display_name}
-                  </option>
-                ))}
-              </select>
+        {files.map((file) => {
+          const isDocx = isDocxFilename(file.filename)
+          return (
+            <div
+              key={file.filename}
+              className="flex flex-col gap-1 text-sm bg-gray-50 border border-gray-200 rounded px-3 py-2"
+            >
+              <span className="text-gray-700 break-words">{file.filename}</span>
+              <div className="flex flex-wrap items-center gap-2">
+                <label className="flex items-center gap-1 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="main-spec"
+                    checked={file.isMain}
+                    onChange={() => onMainChange(file.filename)}
+                    className="w-4 h-4 text-blue-600 cursor-pointer"
+                  />
+                  <span className="text-xs text-gray-500 font-bold">メイン</span>
+                </label>
+                <span className="text-xs text-gray-500 ml-2">種別</span>
+                <select
+                  value={file.type}
+                  onChange={(e) => onTypeChange(file.filename, e.target.value)}
+                  className="border border-gray-300 rounded px-2 py-1 text-sm"
+                >
+                  {specTypesList.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-xs text-gray-500">ツール</span>
+                <select
+                  value={file.tool}
+                  onChange={(e) => onToolChange(file.filename, e.target.value)}
+                  className="border border-gray-300 rounded px-2 py-1 text-sm"
+                  disabled={isDocx}
+                >
+                  {isDocx ? (
+                    <option value="markitdown">MarkItDown</option>
+                  ) : (
+                    availableTools.map((t) => (
+                      <option key={t.name} value={t.name}>
+                        {t.display_name}
+                      </option>
+                    ))
+                  )}
+                </select>
+                {isDocx && (
+                  <span className="text-xs text-orange-600">WordはMarkItDownのみ対応</span>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
 
       <p className="text-xs text-gray-400 mt-2">

--- a/versions/v0.7.0/frontend/src/features/reviewer/index.tsx
+++ b/versions/v0.7.0/frontend/src/features/reviewer/index.tsx
@@ -221,10 +221,10 @@ export function Reviewer() {
 
       {/* Spec files section */}
       <Card className="mb-6">
-        <h2 className="text-lg font-semibold text-gray-800 mb-4">設計書 (Excel)</h2>
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">設計書 (Excel / Word)</h2>
         <div className="flex items-center gap-2 mb-2">
           <FileInputButton
-            accept=".xlsx,.xls"
+            accept=".xlsx,.xls,.docx"
             multiple
             onFilesSelect={addSpecFiles}
             label="ファイルを選択"


### PR DESCRIPTION
# PR: MarkItDown を用いた Word（.docx）対応

## 概要

Closes #26

[MarkITDownの機能を用いたワード対応について](https://github.com/elvezjp/spec-code-ai-reviewer/issues/26) に対応し、設計書として Word（.docx）を選択・変換できるようにしました。Word 選択時は変換ツールを MarkItDown に固定します。

## 変更内容

### フロントエンド（versions/v0.7.0）

#### 1. ファイル入力（`index.tsx`）
- `FileInputButton` の `accept` に `.docx` を追加（`.xlsx,.xls,.docx`）
- カード見出しを「設計書 (Excel)」から「設計書 (Excel / Word)」に変更

#### 2. ファイル変換フック（`useFileConversion.ts`）
- **Word 判定**: 拡張子 `.docx` のみで判定する `isDocxFilename`、`.doc` 除外用の `isDocFilename` を追加
- **addSpecFiles**:
  - 拡張子 `.doc` を除外し、除外件数があれば `setSpecStatus` で「.doc形式は非対応です。.docx形式で保存し直してください（n件を除外）」を表示
  - 除外後の先頭に `isMain` を付与
  - `.docx` には `tool: 'markitdown'`、`type` は `DEFAULT_TYPE`（設計書）のまま
- **setSpecTool**: .docx に対して excel2md 等を指定しても無視し、`markitdown` を維持（ガード）
- **applyToolToAll**: 一括で excel2md を選んでも、.docx には適用せず `markitdown` のまま
- **convertSpecs**: API 送信前に .docx の `tool` を `'markitdown'` に正規化（防御的な二重チェック）

#### 3. ファイルリスト UI（`SpecFileList.tsx`）
- .docx 行のツール選択を固定: `disabled` かつ option は MarkItDown のみ
- 「WordはMarkItDownのみ対応」の補足テキストを .docx 行に表示

#### 4. テスト（`useFileConversion.test.ts`）
- `.docx` 追加時: `tool` が `markitdown`、`type` が設計書
- `.doc` のみ: 除外され、`specStatus` にエラー
- `.doc` 混在: 除外後、残りの先頭がメイン、.docx は `markitdown`
- **setSpecTool**: .docx に excel2md を指定しても `markitdown` のまま
- **applyToolToAll**: .docx と Excel 混在で excel2md 適用時、.docx は `markitdown` のまま
- **convertSpecs**: .docx を含むとき、API に `tool: 'markitdown'` が渡ること

### ドキュメント
- `docs/20260125-word-support-plan.md`: 変更計画書を追加（実装の参照用）

## 非対応（今回のスコープ外）

- バックエンド API の拡張子チェック（`convert.py` で `.docx` を受け付ける修正）は別 PR 想定
- `.doc`（旧形式）は UI で除外し、エラーメッセージで `.docx` を案内

## 動作確認の観点

- [ ] .docx を選択し、ツールが MarkItDown に固定されている
- [ ] 複数ファイル（.docx + .xlsx）混在時、.docx は常に MarkItDown
- [ ] 一括で excel2md を適用しても、.docx は MarkItDown のまま
- [ ] .doc を選択した場合、除外されエラーメッセージが表示される
- [ ] 既存の Excel（.xlsx / .xls）の挙動に変更がない

## 補足

- 種別（spec type）には Word を追加していません。Word は**ファイル形式（拡張子）**でのみ扱います。
- バックエンドで `.docx` を受け付ける修正が入るまで、.docx の変換はバックエンドで失敗する可能性があります。計画書の「バックエンドとの連携方針」を参照してください。
