### PR TITLE
summaryMaxCharsにバックエンドバリデーションを追加

### DIFF
--- a/versions/v0.9.4/backend/app/models/schemas.py
+++ b/versions/v0.9.4/backend/app/models/schemas.py
@@ -308,7 +308,7 @@ class SplitSettingsDetail(BaseModel):
     splitInstructions: str | None = None
     maxSubsections: int | None = None
     summaryMode: Literal["text", "ai"] | None = None       # サマリー生成モード
-    summaryMaxChars: int | None = None                      # テキストモード時の文字数上限
+    summaryMaxChars: int | None = Field(default=None, ge=10, le=1000)  # テキストモード時の文字数上限
 
 
 class SplitMarkdownRequest(BaseModel):
@@ -329,7 +329,7 @@ class SplitMarkdownRequest(BaseModel):
     preExcludedSections: list[int] | None = None  # 事前除外セクションの start_line リスト
     # サマリー生成関連フィールド
     summaryMode: Literal["text", "ai"] | None = None  # グローバルサマリーモード（デフォルト: text）
-    summaryMaxChars: int | None = None  # グローバル文字数上限（デフォルト: 100）
+    summaryMaxChars: int | None = Field(default=None, ge=10, le=1000)  # グローバル文字数上限（デフォルト: 100）
 
 
 class DocumentPart(BaseModel):

--- a/versions/v0.9.4/spec.md
+++ b/versions/v0.9.4/spec.md
@@ -2323,7 +2323,7 @@ Markdownをセクション単位で分割する（md2map使用）。分割モー
 | pre_excluded_sections | - | 事前除外セクションの `start_line` リスト。指定されたセクションは分割処理の対象から除外される |
 | maxSubsections | - | NLP/AIモードの1セクションあたり最大サブスプリット数。デフォルト: 5 |
 | summaryMode | - | サマリーモード（`text` / `ai`）。`text` はルールベース、`ai` はLLMによるサマリー生成。デフォルト: `ai` |
-| summaryMaxChars | - | サマリー最大文字数。デフォルト: 通常セクション100 / 事前重要指定セクション300 |
+| summaryMaxChars | - | サマリー最大文字数（10〜1000）。デフォルト: 通常セクション100 / 事前重要指定セクション300 |
 
 `pre_important_sections` が指定された場合、`normal_split_settings` の設定がデフォルトの分割設定として適用され、`pre_important_split_settings` の設定が事前重要指定セクションにのみ上書き適用される。`pre_important_sections` が未指定の場合は従来通り `splitMode` が使用される。
 


### PR DESCRIPTION
## Summary
- `schemas.py`の`SplitSettingsDetail.summaryMaxChars`と`SplitMarkdownRequest.summaryMaxChars`に`Field(ge=10, le=1000)`を追加
- フロントエンドの制約(`min={10}`, `max={1000}`)と整合させ、API直接呼び出し時の不正値を防止
- `spec.md`にバリデーション範囲を追記

closes #75

## Test plan
- [x] 既存の単体テスト36件が全てパス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)