### PR TITLE
バックエンドのLLM設定をmd2mapに常に渡すよう簡素化

### DIFF
--- a/versions/v0.9.5/backend/app/routers/split.py
+++ b/versions/v0.9.5/backend/app/routers/split.py
@@ -161,26 +161,14 @@ async def split_markdown(request: SplitMarkdownRequest):
                 summary_mode = request.summaryMode or "text"
                 summary_max_chars = request.summaryMaxChars or 100
 
-            # AIモードの場合のみ LLMConfig を変換
-            md2map_llm_config = None
-            if split_mode == "ai":
-                md2map_llm_config = _convert_to_md2map_llm_config(
-                    request.llmConfig
-                )
-
-            # AIサマリーモードの場合もLLM設定が必要
-            if summary_mode == "ai" and md2map_llm_config is None:
-                md2map_llm_config = _convert_to_md2map_llm_config(request.llmConfig)
+            # LLMConfig を変換（md2map は遅延初期化のため、常に渡しても不要なら無視される）
+            md2map_llm_config = _convert_to_md2map_llm_config(request.llmConfig)
 
             # section_overrides の構築（事前重要指定セクション用 + 事前除外セクション用）
             section_overrides = None
             if has_pre_important and request.preImportantSplitSettings:
                 pre_settings = request.preImportantSplitSettings
                 pre_split_mode = pre_settings.splitMode or split_mode
-                if pre_split_mode == "ai" and md2map_llm_config is None:
-                    md2map_llm_config = _convert_to_md2map_llm_config(
-                        request.llmConfig
-                    )
                 section_overrides = [
                     {
                         "start_line": start_line,


### PR DESCRIPTION
## Summary

- `split.py` の `md2map_llm_config` 構築時の条件分岐（`split_mode == "ai"` / `summary_mode == "ai"` / `pre_split_mode == "ai"`）を削除
- `_convert_to_md2map_llm_config(request.llmConfig)` を常に呼び出すよう変更
- md2map は遅延初期化のため、LLMが不要なモードでは `llm_config` を渡しても無視される

## Test plan

- [x] バックエンドテスト全件パス（190件）

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)