### PR TITLE
feat: OpenAI互換API（Kimi/Moonshot AI等）向けBase URL設定対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - Unreleased
 
+### Added
+- **Base URL support for OpenAI-compatible APIs (Kimi / Moonshot AI, etc.)** (#123): The config file generator's `openai` provider now has an optional "Base URL" field, passed through the config file to the backend as part of `llmConfig`. When set, the OpenAI client connects to the specified endpoint (e.g. `https://api.moonshot.ai/v1`) and sends `max_tokens` instead of `max_completion_tokens` for compatibility. When left empty, behavior is unchanged (official OpenAI API)
+
 ### Changed
 - **Repository restructured to keep only the latest code at the root** (#103): The `versions/` directory (v0.5.0–v0.9.9 snapshots) has been removed; `versions/v0.9.9/backend` and `versions/v0.9.9/frontend` were promoted to `backend/` and `frontend/` at the repository root. Version management now uses git tags — to use the old multi-version layout, check out the `v0.9.9` tag
 - **excel2md is now installed from PyPI** (#100): Replaced the `sys.path` injection of the local `excel2md/` directory with a normal dependency (`excel2md>=2.2.1`) and direct imports of `excel2md.cli` / `excel2md.runner`

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -9,6 +9,9 @@
 
 ## [0.10.0] - Unreleased
 
+### Added
+- **OpenAI互換API（Kimi / Moonshot AI 等）向けの Base URL 設定に対応** (#123): 設定ファイルジェネレーターの `openai` プロバイダーに任意の「Base URL」欄を追加し、設定ファイル経由で `llmConfig` の一部としてバックエンドに受け渡す。指定時は OpenAI クライアントが指定エンドポイント（例: `https://api.moonshot.ai/v1`）に接続し、互換性のため `max_completion_tokens` の代わりに `max_tokens` を送信する。未入力時は従来どおり OpenAI 公式 API に接続（既存動作に影響なし）
+
 ### Changed
 - **最新コードのみをルートで保持する構成に変更** (#103): `versions/` ディレクトリ（v0.5.0〜v0.9.9 のスナップショット）を廃止し、`versions/v0.9.9/backend` / `versions/v0.9.9/frontend` をリポジトリルートの `backend/` / `frontend/` に昇格。バージョン管理は git tag に移行し、旧構成を利用する場合は `v0.9.9` タグを checkout する
 - **excel2md を PyPI からインストールする方式に変更** (#100): ローカル `excel2md/` ディレクトリの `sys.path` 注入を廃止し、通常の依存関係（`excel2md>=2.2.1`）と `excel2md.cli` / `excel2md.runner` の直接 import に置き換え

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -55,6 +55,10 @@ class LLMConfig(BaseModel):
     provider: Literal["anthropic", "bedrock", "openai"]
     model: str
     apiKey: str | None = Field(default=None, validation_alias=AliasChoices("apiKey", "api_key"))  # Anthropic/OpenAI用
+    baseUrl: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("baseUrl", "base_url"),
+    )  # OpenAI互換API（Moonshot AI等）の接続先URL。未指定時はOpenAI公式API
     accessKeyId: str | None = Field(
         default=None,
         validation_alias=AliasChoices("accessKeyId", "access_key_id"),

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -15,13 +15,14 @@ class OpenAIProvider(LLMProvider):
     """OpenAI API プロバイダー
 
     ユーザー指定のAPIキーを使用してOpenAI APIを呼び出す。
+    baseUrlを指定した場合はOpenAI互換API（Moonshot AI等）に接続する。
     """
 
     def __init__(self, llm_config: LLMConfig):
         """OpenAIProviderを初期化する
 
         Args:
-            llm_config: LLM設定（apiKeyが必須）
+            llm_config: LLM設定（apiKeyが必須、baseUrlは任意）
 
         Raises:
             ValueError: APIキーが指定されていない場合
@@ -29,9 +30,33 @@ class OpenAIProvider(LLMProvider):
         if not llm_config.apiKey:
             raise ValueError("OpenAI APIキーが指定されていません")
 
-        self._client = OpenAI(api_key=llm_config.apiKey)
+        self._base_url = llm_config.baseUrl
+        if llm_config.baseUrl:
+            self._client = OpenAI(
+                api_key=llm_config.apiKey, base_url=llm_config.baseUrl
+            )
+        else:
+            self._client = OpenAI(api_key=llm_config.apiKey)
         self._model_id = llm_config.model
         self._max_tokens = llm_config.maxTokens
+
+    def _create_chat_completion(self, messages: list[dict], max_tokens: int):
+        """Chat Completions APIを呼び出す
+
+        OpenAI互換APIにはmax_completion_tokens未対応のものがあるため、
+        baseUrl指定時は従来のmax_tokensパラメータを使用する。
+        """
+        if self._base_url:
+            return self._client.chat.completions.create(
+                model=self._model_id,
+                max_tokens=max_tokens,
+                messages=messages,
+            )
+        return self._client.chat.completions.create(
+            model=self._model_id,
+            max_completion_tokens=max_tokens,
+            messages=messages,
+        )
 
     @property
     def provider_name(self) -> str:
@@ -58,13 +83,12 @@ class OpenAIProvider(LLMProvider):
         system_prompt, user_message = self._build_prompts(request)
 
         try:
-            response = self._client.chat.completions.create(
-                model=self._model_id,
-                max_completion_tokens=self._max_tokens,
+            response = self._create_chat_completion(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message},
                 ],
+                max_tokens=self._max_tokens,
             )
 
             usage = response.usage
@@ -92,13 +116,12 @@ class OpenAIProvider(LLMProvider):
         self, system_prompt: str, user_message: str
     ) -> tuple[str, int, int]:
         try:
-            response = self._client.chat.completions.create(
-                model=self._model_id,
-                max_completion_tokens=self._max_tokens,
+            response = self._create_chat_completion(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message},
                 ],
+                max_tokens=self._max_tokens,
             )
             usage = response.usage
             return (
@@ -118,10 +141,9 @@ class OpenAIProvider(LLMProvider):
         try:
             # 最小限のトークンでAPIを呼び出して接続確認
             # GPT-5.2系は出力トークン数が少なすぎるとエラーになるため、余裕を持たせる
-            self._client.chat.completions.create(
-                model=self._model_id,
-                max_completion_tokens=16,
+            self._create_chat_completion(
                 messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
             )
             return {"status": "connected"}
         except AuthenticationError:
@@ -138,13 +160,12 @@ class OpenAIProvider(LLMProvider):
         )
 
         try:
-            response = self._client.chat.completions.create(
-                model=self._model_id,
-                max_completion_tokens=self._max_tokens,
+            response = self._create_chat_completion(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message},
                 ],
+                max_tokens=self._max_tokens,
             )
             return response.choices[0].message.content or ""
         except Exception as e:

--- a/backend/tests/test_openai_service.py
+++ b/backend/tests/test_openai_service.py
@@ -213,3 +213,104 @@ class TestOpenAIProviderExecuteReview:
 
         assert result.success is False
         assert "認証エラー" in result.error
+
+
+class TestOpenAIProviderBaseUrl:
+    """baseUrl指定時（OpenAI互換API）のテスト"""
+
+    @patch("app.services.openai_service.OpenAI")
+    def test_init_with_base_url(self, mock_openai_class):
+        """baseUrl指定時はOpenAIクライアントにbase_urlが渡される"""
+        config = LLMConfig(
+            provider="openai",
+            model="kimi-k2-0711-preview",
+            apiKey="test-api-key",
+            baseUrl="https://api.moonshot.ai/v1",
+        )
+
+        OpenAIProvider(config)
+
+        mock_openai_class.assert_called_once_with(
+            api_key="test-api-key", base_url="https://api.moonshot.ai/v1"
+        )
+
+    @patch("app.services.openai_service.OpenAI")
+    def test_init_without_base_url(self, mock_openai_class):
+        """baseUrl未指定時はbase_urlを渡さない（OpenAI公式API）"""
+        config = LLMConfig(
+            provider="openai",
+            model="gpt-4o",
+            apiKey="test-api-key",
+        )
+
+        OpenAIProvider(config)
+
+        mock_openai_class.assert_called_once_with(api_key="test-api-key")
+
+    def test_base_url_snake_case_alias(self):
+        """base_url（スネークケース）エイリアスでも受け付ける"""
+        config = LLMConfig.model_validate(
+            {
+                "provider": "openai",
+                "model": "kimi-k2-0711-preview",
+                "api_key": "test-api-key",
+                "base_url": "https://api.moonshot.ai/v1",
+            }
+        )
+
+        assert config.baseUrl == "https://api.moonshot.ai/v1"
+
+    @patch("app.services.openai_service.OpenAI")
+    def test_send_message_uses_max_tokens_with_base_url(self, mock_openai_class):
+        """baseUrl指定時はmax_completion_tokensではなくmax_tokensを使用する"""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_client.chat.completions.create.return_value = mock_response
+
+        config = LLMConfig(
+            provider="openai",
+            model="kimi-k2-0711-preview",
+            apiKey="test-api-key",
+            baseUrl="https://api.moonshot.ai/v1",
+            maxTokens=8192,
+        )
+        provider = OpenAIProvider(config)
+
+        provider.send_message("system", "user")
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 8192
+        assert "max_completion_tokens" not in kwargs
+
+    @patch("app.services.openai_service.OpenAI")
+    def test_send_message_uses_max_completion_tokens_without_base_url(
+        self, mock_openai_class
+    ):
+        """baseUrl未指定時は従来どおりmax_completion_tokensを使用する"""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_client.chat.completions.create.return_value = mock_response
+
+        config = LLMConfig(
+            provider="openai",
+            model="gpt-4o",
+            apiKey="test-api-key",
+            maxTokens=8192,
+        )
+        provider = OpenAIProvider(config)
+
+        provider.send_message("system", "user")
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 8192
+        assert "max_tokens" not in kwargs

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.9.9",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.9.9",
+      "version": "0.10.0",
       "dependencies": {
         "jszip": "^3.10.1",
         "lucide-react": "^0.562.0",

--- a/frontend/src/core/types/index.ts
+++ b/frontend/src/core/types/index.ts
@@ -17,6 +17,7 @@ export type LlmProvider = 'anthropic' | 'bedrock' | 'openai'
 export interface LlmSettings {
   provider: LlmProvider
   apiKey?: string
+  baseUrl?: string
   accessKeyId?: string
   secretAccessKey?: string
   region?: string

--- a/frontend/src/features/config-file-generator/schema/configSchema.ts
+++ b/frontend/src/features/config-file-generator/schema/configSchema.ts
@@ -81,6 +81,12 @@ export const CONFIG_SCHEMA: ConfigSchema = {
             fields: [
               { id: 'provider', type: 'fixed', value: 'openai' },
               { id: 'apiKey', label: 'API Key', type: 'password', required: true },
+              {
+                id: 'baseUrl',
+                label: 'Base URL（OpenAI互換APIを使う場合のみ）',
+                type: 'text',
+                placeholder: 'https://api.moonshot.ai/v1',
+              },
               { id: 'maxTokens', label: 'Max Tokens', type: 'number', default: 16384, required: true },
               {
                 id: 'models',

--- a/frontend/src/features/config-file-generator/services/markdownGenerator.ts
+++ b/frontend/src/features/config-file-generator/services/markdownGenerator.ts
@@ -71,6 +71,10 @@ function generateLlmSection(formState: ConfigFormState): string {
         })
       }
     } else {
+      // 任意フィールドが未入力の場合は出力しない
+      const isRequired = 'required' in field && field.required
+      const isEmpty = value === undefined || value === null || String(value).trim() === ''
+      if (field.type !== 'fixed' && !isRequired && isEmpty) return
       md += `- ${field.id}: ${value ?? ''}\n`
     }
   })

--- a/frontend/src/features/config-file-generator/types/index.ts
+++ b/frontend/src/features/config-file-generator/types/index.ts
@@ -12,6 +12,7 @@ export interface ConfigFormState {
 export interface LlmFieldValues {
   provider: LlmProvider
   apiKey?: string
+  baseUrl?: string
   accessKeyId?: string
   secretAccessKey?: string
   region?: string

--- a/frontend/src/features/reviewer/hooks/useReviewerSettings.ts
+++ b/frontend/src/features/reviewer/hooks/useReviewerSettings.ts
@@ -117,6 +117,7 @@ export function useReviewerSettings(): UseReviewerSettingsReturn {
         model: selectedModel || reviewerConfig.llm.models?.[0] || '',
         maxTokens: reviewerConfig.llm.maxTokens || DEFAULT_LLM_SETTINGS.maxTokens,
         apiKey: reviewerConfig.llm.apiKey,
+        baseUrl: reviewerConfig.llm.baseUrl,
         accessKeyId: reviewerConfig.llm.accessKeyId,
         secretAccessKey: reviewerConfig.llm.secretAccessKey,
         region: reviewerConfig.llm.region,
@@ -194,6 +195,7 @@ export function useReviewerSettings(): UseReviewerSettingsReturn {
 
     const llmKeyMap: Record<string, string> = {
       api_key: 'apiKey',
+      base_url: 'baseUrl',
       access_key_id: 'accessKeyId',
       secret_access_key: 'secretAccessKey',
       max_tokens: 'maxTokens',

--- a/frontend/src/features/reviewer/types/index.ts
+++ b/frontend/src/features/reviewer/types/index.ts
@@ -77,6 +77,7 @@ export interface LlmConfig {
   model: string
   maxTokens: number
   apiKey?: string
+  baseUrl?: string
   accessKeyId?: string
   secretAccessKey?: string
   region?: string


### PR DESCRIPTION
Closes #123

## 概要

Kimi（Moonshot AI）などの OpenAI 互換 API を利用できるよう、設定ファイルから Base URL を指定できるようにする。Moonshot AI は専用 SDK を提供しておらず、[公式ドキュメント](https://platform.moonshot.ai/docs/guide/migrating-from-openai-to-kimi)で OpenAI SDK の `base_url` 差し替えを正式な接続方法としているため、この方式が Kimi 対応の正式実装となる。

## 変更内容

### バックエンド

- `LLMConfig` に `baseUrl: str | None = None` を追加（`base_url` エイリアス付き）
- `OpenAIProvider` で `baseUrl` 指定時のみ `OpenAI(api_key=..., base_url=...)` で接続先を差し替え
- OpenAI 互換 API には `max_completion_tokens` 非対応のものがあるため、`baseUrl` 指定時は従来の `max_tokens` パラメータを送信する `_create_chat_completion()` ヘルパーを追加（4箇所の呼び出しを集約）

### フロントエンド

- 設定ファイルジェネレーターの openai ケースに「Base URL（OpenAI互換APIを使う場合のみ）」の任意入力欄を追加（placeholder: `https://api.moonshot.ai/v1`）
- 任意フィールドが未入力の場合は設定ファイル（`reviewer-config.md`）に出力しないよう `markdownGenerator.ts` を変更
- 設定ファイルパース（`useReviewerSettings.ts`）に `base_url → baseUrl` マッピングを追加し、バックエンドへ送る `llmConfig` に `baseUrl` を含める
- 型定義（`LlmSettings` / `LlmConfig` / `LlmFieldValues`）に `baseUrl?: string` を追加

### その他

- `frontend/package-lock.json` のバージョンを `package.json`（0.10.0）に同期

## 互換性

**Base URL 未入力時の挙動は従来と完全に同一**（OpenAI 公式 API に接続、`max_completion_tokens` を送信）。既存の Anthropic / Bedrock / OpenAI 利用者への影響はない。

## テスト

- バックエンド: `uv run pytest tests/` 196件成功（baseUrl 関連の追加テスト5件を含む: クライアント生成の base_url 有無、`max_tokens` / `max_completion_tokens` の切り替え、スネークケースエイリアス）
- フロントエンド: `npm test` 212件成功、`npm run build` 成功
- 手動確認: ローカル起動し、設定ファイルジェネレーター（openai 選択時）に Base URL 欄が表示されること、未入力時に設定ファイルへ出力されないことを確認

## レビュー時の注意点

- 実際の Kimi API に対する疎通確認（実キーでの接続テスト・レビュー実行）は未実施。マージ前または後に実キーで一度確認を推奨
- `baseUrl` 指定時に `max_tokens` へ切り替える仕様は、互換 API 全般への配慮（Kimi は `max_tokens` 対応）。OpenAI 公式に Base URL を指定するケース（通常ない）では `max_tokens` が送られる点に留意

🤖 Generated with [Claude Code](https://claude.com/claude-code)
