### PR TITLE
fix: 接続テストでOpenAI互換APIのBase URLを引き継ぐ

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -225,9 +225,15 @@ class TestConnectionRequest(BaseModel):
     provider/modelが未指定の場合はシステムLLM（Bedrock）をテストする。
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     provider: Literal["anthropic", "bedrock", "openai"] | None = None
     model: str | None = None
     apiKey: str | None = None
+    baseUrl: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("baseUrl", "base_url"),
+    )
     accessKeyId: str | None = None
     secretAccessKey: str | None = None
     region: str | None = None

--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -115,6 +115,7 @@ async def test_llm_connection(request: TestConnectionRequest):
             provider=request.provider,
             model=request.model or "",
             apiKey=request.apiKey,
+            baseUrl=request.baseUrl,
             accessKeyId=request.accessKeyId,
             secretAccessKey=request.secretAccessKey,
             region=request.region,

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -17,6 +17,7 @@ from app.models.schemas import (
     DesignFile,
     ReviewRequest,
     SystemPrompt,
+    TestConnectionRequest as LLMTestConnectionRequest,
 )
 
 
@@ -184,3 +185,31 @@ class TestValidation:
             systemPrompt=create_system_prompt(),
         )
         assert request.designs is not None
+
+
+class TestConnectionRequestSchema:
+    """TestConnectionRequest のテスト"""
+
+    def test_base_url_camel_case(self):
+        """baseUrlを接続テスト設定として受け付ける"""
+        request = LLMTestConnectionRequest(
+            provider="openai",
+            model="moonshot-v1-8k",
+            apiKey="test-key",
+            baseUrl="https://api.moonshot.ai/v1",
+        )
+
+        assert request.baseUrl == "https://api.moonshot.ai/v1"
+
+    def test_base_url_snake_case_alias(self):
+        """base_urlエイリアスでも接続テスト設定として受け付ける"""
+        request = LLMTestConnectionRequest.model_validate(
+            {
+                "provider": "openai",
+                "model": "moonshot-v1-8k",
+                "apiKey": "test-key",
+                "base_url": "https://api.moonshot.ai/v1",
+            }
+        )
+
+        assert request.baseUrl == "https://api.moonshot.ai/v1"

--- a/frontend/src/__tests__/features/reviewer/services/api_response_check.test.ts
+++ b/frontend/src/__tests__/features/reviewer/services/api_response_check.test.ts
@@ -281,3 +281,34 @@ describe('fetchHealth', () => {
     }
   })
 })
+
+describe('testLlmConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('OpenAI互換APIのbaseUrlをPOST本文に含める', async () => {
+    ;(global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'connected', provider: 'openai', model: 'moonshot-v1-8k' }),
+    })
+
+    await testLlmConnection({
+      provider: 'openai',
+      model: 'moonshot-v1-8k',
+      apiKey: 'test-key',
+      baseUrl: 'https://api.moonshot.ai/v1',
+    })
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/test-connection', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'openai',
+        model: 'moonshot-v1-8k',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.moonshot.ai/v1',
+      }),
+    })
+  })
+})

--- a/frontend/src/features/reviewer/index.tsx
+++ b/frontend/src/features/reviewer/index.tsx
@@ -795,6 +795,7 @@ export function Reviewer() {
           provider: llmConfig.provider,
           model: selectedModel || llmConfig.model,
           apiKey: llmConfig.apiKey,
+          baseUrl: llmConfig.baseUrl,
           accessKeyId: llmConfig.accessKeyId,
           secretAccessKey: llmConfig.secretAccessKey,
           region: llmConfig.region,

--- a/frontend/src/features/reviewer/services/api.ts
+++ b/frontend/src/features/reviewer/services/api.ts
@@ -149,6 +149,7 @@ export interface TestConnectionRequest {
   provider?: string
   model?: string
   apiKey?: string
+  baseUrl?: string
   accessKeyId?: string
   secretAccessKey?: string
   region?: string


### PR DESCRIPTION
## Summary
- 接続テスト用リクエストで `baseUrl` / `base_url` を受け取り、`LLMConfig` に渡すよう修正
- フロントの接続テストPOST本文に `llmConfig.baseUrl` を含めるよう修正
- バックエンド/フロント双方にBase URL引き継ぎの回帰テストを追加

## Test plan
- `cd backend && ./.venv/bin/python -m pytest tests/test_schemas.py`
- `cd frontend && npm run test:run -- src/__tests__/features/reviewer/services/api_response_check.test.ts`

## Notes
- `docs/sample/` の未追跡更新はPRに含めていません。

Made with [Cursor](https://cursor.com)