### PR TITLE
fix: 分割APIのmd2map呼び出しに設定ファイルのbaseUrlとmaxTokensを引き継ぐ

### DIFF
--- a/backend/app/routers/split.py
+++ b/backend/app/routers/split.py
@@ -52,10 +52,13 @@ def _convert_to_md2map_llm_config(llm_config: LLMConfig | None):
         provider=llm_config.provider,
         model=llm_config.model,
         api_key=llm_config.apiKey,
+        base_url=llm_config.baseUrl,
         access_key_id=llm_config.accessKeyId,
         secret_access_key=llm_config.secretAccessKey,
         region=llm_config.region,
-        max_tokens=800,
+        # 思考型モデルは思考トークンも max_tokens を消費するため、
+        # 固定値ではなく設定ファイルの maxTokens を引き継ぐ
+        max_tokens=llm_config.maxTokens,
     )
 
 

--- a/backend/tests/test_split.py
+++ b/backend/tests/test_split.py
@@ -25,6 +25,8 @@
 - UT-SPL-022: split_markdown() - summaryMode/summaryMaxChars を section_overrides に渡す
 - UT-SPL-023: split_markdown() - summaryMode "ai" で LLM 設定が初期化される
 - UT-SPL-024: split_markdown() - parse() の warnings がレスポンスに含まれる
+- UT-SPL-025: _convert_to_md2map_llm_config() - baseUrl が md2map に引き継がれる
+- UT-SPL-026: _convert_to_md2map_llm_config() - baseUrl 未指定時は None
 """
 
 from unittest.mock import MagicMock, patch
@@ -1509,3 +1511,45 @@ class TestSplitMarkdownSummaryAPI:
         assert len(data["warnings"]) == 2
         assert "AI API call failed" in data["warnings"][0]
         assert "ルールベース" in data["warnings"][1]
+
+
+class TestConvertToMd2mapLLMConfig:
+    """_convert_to_md2map_llm_config() のテスト"""
+
+    def test_ut_spl_025_base_url_passed(self):
+        """UT-SPL-025: baseUrl が md2map の LLMConfig に引き継がれる"""
+        from app.models.schemas import LLMConfig
+        from app.routers.split import _convert_to_md2map_llm_config
+
+        llm_config = LLMConfig(
+            provider="openai",
+            model="kimi-k2-turbo-preview",
+            apiKey="sk-test",
+            baseUrl="https://api.moonshot.ai/v1",
+            maxTokens=32768,
+        )
+
+        result = _convert_to_md2map_llm_config(llm_config)
+
+        assert result.provider == "openai"
+        assert result.model == "kimi-k2-turbo-preview"
+        assert result.api_key == "sk-test"
+        assert result.base_url == "https://api.moonshot.ai/v1"
+        assert result.max_tokens == 32768
+
+    def test_ut_spl_026_base_url_default_none(self):
+        """UT-SPL-026: baseUrl 未指定時は base_url が None（OpenAI公式API）"""
+        from app.models.schemas import LLMConfig
+        from app.routers.split import _convert_to_md2map_llm_config
+
+        llm_config = LLMConfig(
+            provider="openai",
+            model="gpt-4o-mini",
+            apiKey="sk-test",
+        )
+
+        result = _convert_to_md2map_llm_config(llm_config)
+
+        assert result.base_url is None
+        # maxTokens 未指定時はスキーマのデフォルト値（16384）が引き継がれる
+        assert result.max_tokens == 16384

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -712,8 +712,8 @@ xlsx = [
 
 [[package]]
 name = "md2map"
-version = "0.4.3"
-source = { git = "https://github.com/elvezjp/md2map.git?branch=main#53a9b76ccf00caeab562b56a7a3ce83ff7e10a65" }
+version = "0.5.0"
+source = { git = "https://github.com/elvezjp/md2map.git?branch=main#b5fc62acecdc5729fe4c9c9dd72f17b42cc25457" }
 dependencies = [
     { name = "add-line-numbers" },
 ]


### PR DESCRIPTION
## 概要

[PR #124](https://github.com/elvezjp/spec-code-ai-reviewer/pull/124) で追加された OpenAI 互換 API（Kimi 等）の baseUrl 対応が、分割プレビュー時の md2map 呼び出し（AIサマリー生成・AI分割）に引き継がれていなかった問題を修正します。

## 問題

分割プレビューで `summaryMode: "ai"` を使用すると、以下の2つの問題が発生していました。

1. **baseUrl が引き継がれず 401 エラー**
   `_convert_to_md2map_llm_config` が baseUrl を md2map に渡しておらず、互換 API のキーを持ったまま OpenAI 公式 API に接続していました。
   ```
   AI summary generation failed for '...': Error code: 401 - Incorrect API key provided: sk-5gRPW***
   ```
2. **maxTokens 固定値 800 による空レスポンス**
   思考型モデル（kimi-k3 等）は思考トークンも max_tokens を消費するため、800 では可視コンテンツが空になり `OpenAI API returned empty response` が発生していました。

## 変更内容

- `_convert_to_md2map_llm_config` に `base_url=llm_config.baseUrl` を追加
- `max_tokens=800` 固定を廃止し、設定ファイル由来の `maxTokens`（スキーマデフォルト 16384）を引き継ぐよう変更
- md2map を base_url 対応版に更新（`uv.lock` を [md2map#37](https://github.com/elvezjp/md2map/pull/37)・[md2map#39](https://github.com/elvezjp/md2map/pull/39) マージ後の main に再ロック）
- テスト追加: UT-SPL-025（baseUrl/maxTokens の引き継ぎ）、UT-SPL-026（baseUrl 未指定時は None・maxTokens デフォルト）

## 動作確認

- バックエンド全 200 テストがパス
- ローカルの疑似 OpenAI 互換サーバーで E2E 検証: 分割 API のリクエストが baseUrl 先に到達し、Authorization ヘッダー・`max_tokens` パラメータ（互換 API 用）が正しく送信されることを確認
- 実際の Kimi API（kimi-k3）でも分割プレビューの AI サマリー生成が警告なしで完了することを確認

## 関連

- elvezjp/md2map#37（LLMConfig への base_url 追加）
- elvezjp/md2map#39（AI 呼び出し並列化。今回の uv.lock 更新に含まれるが、本 PR では未使用。分割 API から `ai_concurrency` を渡す対応は別途）
- #124（Kimi API 対応 / baseUrl 追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)