### PR TITLE
fix: Windows環境で test_unsanitized_join_would_escape が失敗する問題を修正

### DIFF
--- a/backend/tests/test_safe_path.py
+++ b/backend/tests/test_safe_path.py
@@ -65,5 +65,7 @@ class TestJoinIsContained:
         """サニタイズしない場合は脱出できることを確認（回帰検知用）。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             escaped = os.path.join(tmpdir, "/etc/evil.conf")
-            assert escaped == "/etc/evil.conf"
+            # Windows では join 結果にドライブ文字が付くため、厳密一致は POSIX のみ検証
+            if os.name != "nt":
+                assert escaped == "/etc/evil.conf"
             assert Path(escaped).resolve().parent != Path(tmpdir).resolve()


### PR DESCRIPTION
## 概要

セキュリティ修正（GHSA-97h8-c8cg-hwm2 の一時プライベートフォーク経由のマージ）で追加された `test_safe_path.py` のうち、`test_unsanitized_join_would_escape` が windows-latest のCIで失敗していたため修正します。

## 原因

`os.path.join(tmpdir, "/etc/evil.conf")` の結果を文字列 `"/etc/evil.conf"` と厳密一致で検証していましたが、Windowsではドライブ文字が付いて `C:/etc/evil.conf` となるため不一致になっていました。

一時プライベートフォークではGitHub ActionsのCIが動かないため、マージ後に初めて発覚したものです。

## 修正内容

- 文字列の厳密一致検証はPOSIX環境のみに限定（`os.name != "nt"`）
- 「結合結果が一時ディレクトリの外に出る」ことの検証は全プラットフォームで実施（こちらが本質的な回帰検知）

セキュリティ修正本体（`safe_filename()`）の挙動には変更ありません。

## テスト

- ローカル（macOS）で `test_safe_path.py` 21件 pass を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)